### PR TITLE
Adds metadata + field name support

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -33,4 +33,4 @@ stdenv.mkDerivation rec {
                   openssl postgresql
                   vim ];
 }
-) {}
+) {rust = nixpkgs.rustNightly; }

--- a/src/edsl.rs
+++ b/src/edsl.rs
@@ -66,10 +66,15 @@ macro_rules! holmes_exec {
 #[macro_export]
 macro_rules! predicate {
   ($holmes:ident, $pred_name:ident($($t:tt),*)) => {{
-    let types = vec![$(htype!($holmes, $t),)*];
+    let fields = vec![$(::holmes::engine::types::Field {
+        name: None,
+        description: None,
+        type_: htype!($holmes, $t)
+    },)*];
     $holmes.new_predicate(&::holmes::engine::types::Predicate {
-      name  : stringify!($pred_name).to_string(),
-      types : types
+      name: stringify!($pred_name).to_string(),
+      description: None,
+      fields: fields
     })
   }};
   ($pred_name:ident($($t:tt),*)) => { |holmes: &mut ::holmes::Engine<_,_>| {

--- a/src/edsl.rs
+++ b/src/edsl.rs
@@ -132,6 +132,38 @@ macro_rules! fact {
   }};
 }
 
+#[macro_export]
+macro_rules! clause {
+    ($holmes:ident, $vars:ident, $next:ident, $pred_name:ident($($m:tt),*)) => {{
+        ::holmes::engine::types::Clause {
+            pred_name: stringify!($pred_name).to_string(),
+            args: vec![$(clause_match!($vars, $next, $m)),*]
+        }
+    }};
+    ($holmes:ident, $vars:ident, $next:ident, $pred_name:ident{$($field:ident = $m:tt),*}) => {{
+        use std::collections::HashMap;
+        let pred_name = stringify!($pred_name).to_string();
+        let pred = $holmes.get_predicate(&pred_name)?.unwrap();
+        let mut matches = HashMap::new();
+        let _ = {
+          $(matches.insert(stringify!($field).to_string(), clause_match!($vars, $next, $m)));*
+        };
+        let args: Vec<::holmes::engine::types::MatchExpr> = pred.fields.iter().map(|field| {
+            match field.name {
+                Some(ref name) => match matches.remove(name) {
+                    Some(cm) => cm,
+                    None => ::holmes::engine::types::MatchExpr::Unbound
+                },
+                None => ::holmes::engine::types::MatchExpr::Unbound,
+            }
+        }).collect();
+        ::holmes::engine::types::Clause {
+            pred_name: pred_name,
+            args: args
+        }
+    }};
+}
+
 /// Runs a datalog query against the `Holmes` context
 ///
 /// Matches as per the right hand side of a datalog rule, then returns
@@ -144,14 +176,12 @@ macro_rules! fact {
 /// ```
 #[macro_export]
 macro_rules! query {
-  ($holmes:ident, $($pred_name:ident($($m:tt),*))&*) => {{
+  ($holmes:ident, $($pred_name:ident $inner:tt)&*) => {{
     use std::collections::HashMap;
     let mut vars : HashMap<String, ::holmes::engine::types::Var> = HashMap::new();
     let mut n : ::holmes::engine::types::Var = 0;
-    $holmes.derive(&vec![$(::holmes::engine::types::Clause {
-      pred_name : stringify!($pred_name).to_string(),
-      args : vec![$(clause_match!(vars, n, $m)),*]
-    }),*])
+    let query = vec![$(clause!($holmes, vars, n, $pred_name $inner)),*];
+    $holmes.derive(&query)
   }}
 }
 
@@ -184,57 +214,32 @@ macro_rules! query {
 /// and `bind_match!` macro docs.
 #[macro_export]
 macro_rules! rule {
-  ($holmes:ident, $head_name:ident($($m:tt),*) <= $($body_name:ident($($mb:tt),*))&*,
+  ($holmes:ident, $head_name:ident $head_inner:tt <= $($body_name:ident $body_inner:tt)&*,
    {$(let $bind:tt = $hexpr:tt);*}) => {{
     use std::collections::HashMap;
     let mut vars : HashMap<String, ::holmes::engine::types::Var> = HashMap::new();
     let mut n : ::holmes::engine::types::Var = 0;
+    let body = vec![$(clause!($holmes, vars, n, $body_name $body_inner)),*];
+    let head = clause!($holmes, vars, n, $head_name $head_inner);
     $holmes.new_rule(&::holmes::engine::types::Rule {
-      body : vec![$(::holmes::engine::types::Clause {
-        pred_name : stringify!($body_name).to_string(),
-        args : vec![$(clause_match!(vars, n, $mb)),*]
-      }),*],
-      head : ::holmes::engine::types::Clause {
-        pred_name : stringify!($head_name).to_string(),
-        args : vec![$(clause_match!(vars, n, $m)),*]
-      },
+      body: body,
+      head: head,
       wheres : vec! [$(::holmes::engine::types::WhereClause {
         lhs   : bind_match!(vars, n, $bind),
         rhs   : hexpr!(vars, n, $hexpr)
       }),*]
     })
   }};
-  ($holmes:ident, $head_name:ident($($m:tt),*) <= $($body_name:ident($($mb:tt),*))&*,
-   {$(let $($bind:tt),* = $hexpr:tt);*}) => {{
-    use std::collections::HashMap;
-    let mut vars : HashMap<String, ::holmes::engine::types::Var> = HashMap::new();
-    let mut n : ::holmes::engine::types::Var = 0;
-    $holmes.new_rule(&::holmes::engine::types::Rule {
-      body : vec![$(::holmes::engine::types::Clause {
-        pred_name : stringify!($body_name).to_string(),
-        args : vec![$(clause_match!(vars, n, $mb)),*]
-      }),*],
-      head : ::holmes::engine::types::Clause {
-        pred_name : stringify!($head_name).to_string(),
-        args : vec![$(clause_match!(vars, n, $m)),*]
-      },
-      wheres : vec! [$(::holmes::engine::types::WhereClause {
-        lhs   : ::holmes::engine::types::BindExpr::Destructure(
-                  vec![$(bind_match!(vars, n, $bind)),*]),
-        rhs   : hexpr!(vars, n, $hexpr)
-      }),*]
-    })
-  }};
-  ($($head_name:ident($($m:tt),*)),* <= $($body_name:ident($($mb:tt),*))&*) => {
+  ($($head_name:ident $head_inner:tt),* <= $($body_name:ident $inner:tt)&*) => {
     |holmes: &mut ::holmes::Engine<_,_>| {
-      rule!(holmes, $($head_name($($m),*)),* <= $($body_name($($mb),*))&*, {})
+      rule!(holmes, $($head_name $head_inner),* <= $($body_name $inner)&*, {})
     }
   };
-  ($($head_name:ident($($m:tt),*)),* <=
-   $($body_name:ident($($mb:tt),*))&*, {$(let $($bind:tt),* = $hexpr:tt);*}) => {
+  ($($head_name:ident $head_inner:tt),* <=
+   $($body_name:ident $inner:tt)&*, {$(let $bind:tt = $hexpr:tt);*}) => {
     |holmes: &mut ::holmes::Engine<_,_>| {
-      rule!(holmes, $($head_name($($m),*)),* <=
-                    $($body_name($($mb),*))&*, {$(let $($bind),* = $hexpr);*})
+      rule!(holmes, $($head_name $head_inner),* <=
+                    $($body_name $inner)&*, {$(let $bind = $hexpr);*})
     }
   };
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -95,17 +95,18 @@ impl<FE, FDB> Engine<FE, FDB>
     pub fn new_predicate(&self, pred: &Predicate) -> Result<()> {
 
         // Verify we have at least one argument
-        if pred.types.len() == 0 {
+        if pred.fields.len() == 0 {
             bail!(ErrorKind::Invalid("Predicates must have at least one argument.".to_string()));
         }
 
         // Check for existing predicates/type issues
         match self.fact_db.get_predicate(&pred.name) {
             Some(p) => {
-                if pred.types == p.types {
+                if pred.fields == p.fields {
+                    //TODO should this be return ()
                     ()
                 } else {
-                    bail!(ErrorKind::Type(format!("{:?} != {:?}", pred.types, p.types)));
+                    bail!(ErrorKind::Type(format!("{:?} != {:?}", pred.fields, p.fields)));
                 }
             }
             None => (),
@@ -122,15 +123,15 @@ impl<FE, FDB> Engine<FE, FDB>
     pub fn new_fact(&mut self, fact: &Fact) -> Result<()> {
         match self.fact_db.get_predicate(&fact.pred_name) {
             Some(ref pred) => {
-                if (fact.args.len() != pred.types.len()) ||
+                if (fact.args.len() != pred.fields.len()) ||
                    (!fact.args
                     .iter()
-                    .zip(pred.types.iter())
-                    .all(|(val, ty)| val.type_() == ty.clone())) {
+                    .zip(pred.fields.iter())
+                    .all(|(val, field)| val.type_() == field.type_.clone())) {
                     bail!(ErrorKind::Type(format!("Fact ({:?}) does not \
                                                    match predicate ({:?})",
                                                   fact,
-                                                  pred.types)));
+                                                  pred.fields)));
                 }
             }
             None => bail!(ErrorKind::Invalid("Predicate not registered".to_string())),

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -115,6 +115,12 @@ impl<FE, FDB> Engine<FE, FDB>
         Ok(try!(self.fact_db.new_predicate(pred).chain_err(|| ErrorKind::FactDB)))
     }
 
+    /// Retrieves a named predicate from the database. This is primarily of use for
+    /// retrieving metadata about a predicate for display.
+    pub fn get_predicate(&self, name: &str) -> Result<Option<Predicate>> {
+        Ok(self.fact_db.get_predicate(name))
+    }
+
     /// Adds a new fact to the database
     /// If the fact is already present, a new copy will not be added.
     ///

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -103,7 +103,7 @@ impl<FE, FDB> Engine<FE, FDB>
         match self.fact_db.get_predicate(&pred.name) {
             Some(p) => {
                 if pred.fields == p.fields {
-                    //TODO should this be return ()
+                    // TODO should this be return ()
                     ()
                 } else {
                     bail!(ErrorKind::Type(format!("{:?} != {:?}", pred.fields, p.fields)));

--- a/src/engine/types.rs
+++ b/src/engine/types.rs
@@ -62,9 +62,8 @@ pub struct Field {
 // https://github.com/rust-lang/rust/issues/39128
 impl PartialEq for Field {
     fn eq(&self, other: &Self) -> bool {
-        (self.name == other.name) &&
-            (self.description == other.description) &&
-            (self.type_.eq(&other.type_))
+        (self.name == other.name) && (self.description == other.description) &&
+        (self.type_.eq(&other.type_))
     }
 }
 

--- a/src/engine/types.rs
+++ b/src/engine/types.rs
@@ -14,19 +14,58 @@ use pg::dyn::{Value, Type};
 ///
 /// ```
 /// use holmes::pg::dyn::types;
-/// use holmes::engine::types::Predicate;
+/// use holmes::engine::types::{Predicate, Field};
 /// use std::sync::Arc;
 /// Predicate {
-///   name  : "foo".to_string(),
-///   types : vec![Arc::new(types::UInt64), Arc::new(types::String)]
+///     name: "foo".to_string(),
+///     description: None,
+///     fields: vec![Field {
+///         name: None,
+///         description: None,
+///         type_: Arc::new(types::UInt64)
+///     }, Field {
+///         name: None,
+///         description: None,
+///         type_: Arc::new(types::String)
+///     }]
 /// };
 /// ```
 #[derive(PartialEq,Clone,Debug,Hash,Eq)]
 pub struct Predicate {
     /// Predicate Name
     pub name: String,
-    /// Predicate slot types
-    pub types: Vec<Type>,
+    /// Description of what it means for this predicate to be true.
+    /// Purely documentation, not mechanical
+    pub description: Option<String>,
+    /// Predicate fields
+    pub fields: Vec<Field>,
+}
+
+/// Field for use in a predicate
+/// The name is for use in selective matching or unordered definition,
+/// and the description is to improve readability of code and comprehension of
+/// results.
+/// The `Type` is the only required component of a field, as it defines how to
+/// actually interact with the field.
+#[derive(Clone,Debug,Hash,Eq)]
+pub struct Field {
+    /// Name of field, for use in matching and instantiating predicates
+    pub name: Option<String>,
+    /// Description of the field, purely documentation, not mechanical
+    pub description: Option<String>,
+    /// Type of the predicate, explaining how to store and retrieve
+    /// information from the `FactDB`
+    pub type_: Type,
+}
+
+// Manually implement PartialEq to work around rustc #[derive(PartialEq)] bug
+// https://github.com/rust-lang/rust/issues/39128
+impl PartialEq for Field {
+    fn eq(&self, other: &Self) -> bool {
+        (self.name == other.name) &&
+            (self.description == other.description) &&
+            (self.type_.eq(&other.type_))
+    }
 }
 
 /// A `Fact` is a particular filling of a `Predicate`'s slots such that it is

--- a/src/pg/mod.rs
+++ b/src/pg/mod.rs
@@ -33,7 +33,7 @@ use postgres::{rows, Connection, TlsMode};
 use postgres::params::IntoConnectParams;
 use postgres::types::{FromSql, ToSql};
 
-use engine::types::{Fact, Predicate, MatchExpr, Clause, DBExpr};
+use engine::types::{Fact, Predicate, Field, MatchExpr, Clause, DBExpr};
 use std::cell::RefCell;
 
 pub mod dyn;
@@ -145,9 +145,16 @@ impl PgDB {
         try!(conn.execute("create schema if not exists cache", &[]));
 
         // Create Tables
-        try!(conn.execute("create table if not exists predicates (pred_name \
-                           varchar not null, ordinal int4 not null, type \
-                           varchar not null)",
+        try!(conn.execute("create table if not exists predicates (id serial primary key, \
+                           name varchar not null, \
+                           description varchar)",
+                           &[]));
+        try!(conn.execute("create table if not exists fields (\
+                           pred_id serial references predicates(id), \
+                           ordinal int4 not null, \
+                           type varchar not null, \
+                           name varchar, \
+                           description varchar)",
                           &[]));
         try!(conn.execute("create table if not exists rules (id serial primary key , rule varchar \
                       not null)",
@@ -200,28 +207,37 @@ impl PgDB {
         *self.insert_by_name.borrow_mut() = HashMap::new();
         {
             // Scoped borrow of connection
-            let pred_stmt = try!(self.conn
-                .prepare("select pred_name, type from predicates ORDER BY \
-                          pred_name, ordinal"));
+            let pred_stmt = try!(self.conn.prepare(
+                    "select predicates.name, predicates.description, fields.name, fields.description, fields.type \
+                     from predicates JOIN fields ON predicates.id = fields.pred_id ORDER BY predicates.id, fields.ordinal"));
             let pred_types = try!(pred_stmt.query(&[]));
             for type_entry in pred_types.iter() {
-                let name: String = type_entry.get(0);
-                let h_type_str: String = type_entry.get(1);
+                let mut row = RowIter::new(&type_entry);
+                let name: String = row.next().unwrap();
+                // TODO: there's funny layering of nested options issues here
+                let pred_descr: Option<String> = row.next();
+                let field_name: Option<String> = row.next();
+                let field_descr: Option<String> = row.next();
+                let h_type_str: String = row.next().unwrap();
                 let h_type = match self.get_type(&h_type_str) {
                     Some(ty) => ty,
                     None => types::Trap::new(),
                 };
+                let field = Field {
+                    name: field_name,
+                    description: field_descr,
+                    type_: h_type.clone()
+                };
                 match self.pred_by_name.borrow_mut().entry(name.clone()) {
                     Vacant(entry) => {
-                        let mut types = Vec::new();
-                        types.push(h_type.clone());
                         entry.insert(Predicate {
                             name: name.clone(),
-                            types: types,
+                            description: pred_descr,
+                            fields: vec![field],
                         });
                     }
                     Occupied(mut entry) => {
-                        entry.get_mut().types.push(h_type.clone());
+                        entry.get_mut().fields.push(field);
                     }
                 }
             }
@@ -234,8 +250,9 @@ impl PgDB {
     // Generates a prebuilt insert statement for a given predicate, and stores
     // it in the cache so we don't have to rebuild it every time.
     // TODO: Is it possible for these to be stored prepared statements somehow?
+    // TODO: There might be an issue here with types with multifield width?
     fn gen_insert_stmt(&self, pred: &Predicate) {
-        let args: Vec<String> = pred.types
+        let args: Vec<String> = pred.fields
             .iter()
             .enumerate()
             .map(|(k, _)| format!("${}", k + 1))
@@ -251,27 +268,31 @@ impl PgDB {
     // This function is internal because it does not add it to the object, it
     // _only_ puts record of the predicate into the database.
     fn insert_predicate(&self, pred: &Predicate) -> Result<()> {
-        let &Predicate { ref name, ref types } = pred;
-        for (ordinal, type_) in types.iter().enumerate() {
+        let &Predicate { ref name, ref description, ref fields } = pred;
+        let stmt = self.conn.prepare("insert into predicates (name, description) values ($1, $2) returning id")?;
+        let pred_id: i32 = stmt.query(&[name, description])?.get(0).get(0);
+        for (ordinal, field) in fields.iter().enumerate() {
             try!(self.conn
-                .execute("insert into predicates (pred_name, type, ordinal) \
-                          values ($1, $2, $3)",
-                         &[name,
-                           &type_.name()
-                               .ok_or(ErrorKind::Arg("Predicate type had no name".to_string()))?,
+                .execute("insert into fields (pred_id, name, description, type, ordinal) \
+                          values ($1, $2, $3, $4, $5)",
+                         &[&pred_id,
+                           &field.name,
+                           &field.description,
+                           &field.type_.name()
+                               .ok_or(ErrorKind::Arg("Field type had no name".to_string()))?,
                            &(ordinal as i32)]));
         }
-        let table_str = types.iter()
-            .flat_map(|type_| type_.repr())
+        let table_str = fields.iter()
+            .flat_map(|field| field.type_.repr())
             .enumerate()
             .map(|(ord, repr)| format!("arg{} {}", ord, repr))
             .collect::<Vec<_>>()
             .join(", ");
-        let col_str = types.iter()
-            .flat_map(|type_| {
-                type_.repr()
+        let col_str = fields.iter()
+            .flat_map(|field| {
+                field.type_.repr()
                     .iter()
-                    .map(|_| type_.large_unique())
+                    .map(|_| field.type_.large_unique())
                     .collect::<Vec<_>>()
             })
             .enumerate()
@@ -448,24 +469,24 @@ impl FactDB for PgDB {
                         MatchExpr::Var(v) => {
                             let v = v as usize;
                             if v == var_type.len() {
-                                var_type.push(pred.types[idx].clone())
+                                var_type.push(pred.fields[idx].type_.clone())
                             } else if v > var_type.len() {
                                 bail!(ErrorKind::Arg(format!("Hole between {} and {} in \
                                                               variable numbering.",
                                                              var_type.len() - 1,
                                                              v)));
-                            } else if var_type[v] != pred.types[idx].clone() {
+                            } else if var_type[v] != pred.fields[idx].type_.clone() {
                                 bail!(ErrorKind::Arg(format!("Variable {} attempt to unify \
                                                               incompatible types {:?} and {:?}",
                                                              v,
                                                              var_type[v],
-                                                             pred.types[idx])));
+                                                             pred.fields[idx].type_)));
                             }
                         }
                         // TODO: unify logic with above
                         MatchExpr::SubStr(_, _, var) => {
                             let v = var as usize;
-                            let repr = pred.types[idx].repr();
+                            let repr = pred.fields[idx].type_.repr();
                             if repr.len() != 1 {
                                 bail!(ErrorKind::Arg(format!("Substring matching performed on \
                                                               compound field")));
@@ -473,18 +494,18 @@ impl FactDB for PgDB {
                                 bail!(ErrorKind::Arg(format!("Substring matching performed on \
                                                               non-string or bytes")));
                             } else if v == var_type.len() {
-                                var_type.push(pred.types[idx].clone())
+                                var_type.push(pred.fields[idx].type_.clone())
                             } else if v > var_type.len() {
                                 bail!(ErrorKind::Arg(format!("Hole between {} and {} in \
                                                               variable numbering.",
                                                              var_type.len() - 1,
                                                              v)));
-                            } else if var_type[v] != pred.types[idx].clone() {
+                            } else if var_type[v] != pred.fields[idx].type_.clone() {
                                 bail!(ErrorKind::Arg(format!("Variable {} attempt to unify \
                                                               incompatible types {:?} and {:?}",
                                                              v,
                                                              var_type[v],
-                                                             pred.types[idx])));
+                                                             pred.fields[idx].type_)));
                             }
                         }
                     }
@@ -528,7 +549,7 @@ impl FactDB for PgDB {
                                                    end_str,
                                                    start_str));
                             var_types.push(self.pred_by_name.borrow()[&clause.pred_name]
-                                    .types[idx]
+                                    .fields[idx].type_
                                 .clone());
                         } else {
                             let piece = format!("substring({}.arg{} from {} \
@@ -549,7 +570,7 @@ impl FactDB for PgDB {
                             // in the select, and store the type to know how to extract it.
                             var_names.push(format!("{}.arg{}", alias_name, idx));
                             var_types.push(self.pred_by_name.borrow()[&clause.pred_name]
-                                    .types[idx]
+                                    .fields[idx].type_
                                 .clone());
                         } else {
                             // The variable has occurred correctly, so we add it being equal

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -13,5 +13,6 @@ mod rule_where;
 mod type_extend;
 mod rule_substr;
 mod reboot;
+mod metadata_basic;
 
 mod bugs;

--- a/tests/metadata_basic.rs
+++ b/tests/metadata_basic.rs
@@ -22,7 +22,9 @@ pub fn new_predicate_doc_field() {
 pub fn new_predicate_doc_all() {
     single(&|holmes: &mut Engine| {
         holmes_exec!(holmes, {
-            predicate!(test_pred([first string "This is the first element"], bytes, uint64) : "This is a test predicate")
+            predicate!(test_pred([first string "This is the first element"],
+                                  bytes, uint64)
+                       : "This is a test predicate")
         })
     })
 }
@@ -31,12 +33,14 @@ pub fn new_predicate_doc_all() {
 pub fn predicate_roundtrip() {
     single(&|holmes: &mut Engine| {
         holmes_exec!(holmes, {
-            predicate!(test_pred([first string "This is the first element"], bytes, uint64) : "This is a test predicate")
+            predicate!(test_pred([first string "This is the first element"],
+                                 bytes, uint64)
+                       : "This is a test predicate")
         })?;
-	let pred = holmes.get_predicate("test_pred")?.unwrap();
-	assert_eq!(pred.description.as_ref().unwrap(), "This is a test predicate");
-	assert_eq!(pred.fields[0].name.as_ref().unwrap(), "first");
-	assert_eq!(pred.fields[0].description.as_ref().unwrap(), "This is the first element");
-	Ok(())
+        let pred = holmes.get_predicate("test_pred")?.unwrap();
+        assert_eq!(pred.description.as_ref().unwrap(), "This is a test predicate");
+        assert_eq!(pred.fields[0].name.as_ref().unwrap(), "first");
+        assert_eq!(pred.fields[0].description.as_ref().unwrap(), "This is the first element");
+        Ok(())
     })
 }

--- a/tests/metadata_basic.rs
+++ b/tests/metadata_basic.rs
@@ -1,0 +1,42 @@
+use common::*;
+
+#[test]
+pub fn new_predicate_named_field() {
+    single(&|holmes: &mut Engine| {
+        holmes_exec!(holmes, {
+            predicate!(test_pred([first string], bytes, uint64))
+        })
+    })
+}
+
+#[test]
+pub fn new_predicate_doc_field() {
+    single(&|holmes: &mut Engine| {
+        holmes_exec!(holmes, {
+            predicate!(test_pred([first string "This is the first element"], bytes, uint64))
+        })
+    })
+}
+
+#[test]
+pub fn new_predicate_doc_all() {
+    single(&|holmes: &mut Engine| {
+        holmes_exec!(holmes, {
+            predicate!(test_pred([first string "This is the first element"], bytes, uint64) : "This is a test predicate")
+        })
+    })
+}
+
+#[test]
+pub fn predicate_roundtrip() {
+    single(&|holmes: &mut Engine| {
+        holmes_exec!(holmes, {
+            predicate!(test_pred([first string "This is the first element"], bytes, uint64) : "This is a test predicate")
+        })?;
+	let pred = holmes.get_predicate("test_pred")?.unwrap();
+	assert_eq!(pred.description.as_ref().unwrap(), "This is a test predicate");
+	assert_eq!(pred.fields[0].name.as_ref().unwrap(), "first");
+	assert_eq!(pred.fields[0].description.as_ref().unwrap(), "This is the first element");
+	Ok(())
+    })
+}

--- a/tests/metadata_basic.rs
+++ b/tests/metadata_basic.rs
@@ -44,3 +44,23 @@ pub fn predicate_roundtrip() {
         Ok(())
     })
 }
+
+#[test]
+pub fn named_field_rule() {
+    single(&|holmes: &mut Engine| {
+        holmes_exec!(holmes, {
+            predicate!(test_pred([foo string],
+                                 uint64,
+                                 [bar string]));
+            predicate!(out_pred(string));
+            rule!(out_pred(x) <= test_pred {bar = x, foo = ("woo")});
+            fact!(test_pred("woo", 3, "Right"));
+            fact!(test_pred("wow", 4, "Wrong"))
+        })?;
+
+        let ans = query!(holmes, out_pred(x))?;
+        assert_eq!(ans, vec![["Right".to_value()]]);
+
+        Ok(())
+    })
+}

--- a/tests/rule_where.rs
+++ b/tests/rule_where.rs
@@ -54,7 +54,7 @@ pub fn where_destructure() {
         (n + 1, n + 2)
       });
       rule!(test_pred(y, (vec![2u8,2u8]), z) <= test_pred((3), [_], x), {
-        let y, z = {succs([x])}
+        let {y, z} = {succs([x])}
       });
       fact!(test_pred(3, vec![0u8,1u8], 16))
     }));


### PR DESCRIPTION
Allow fields in predicates to be named, rules to match by field name in addition to slot number, and documentation to be attached to both fields and predicates.

Closes #23 