### PR TITLE
Run rules asynchronously

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ rustc-serialize = "0.3"
 log = "0.3"
 error-chain = "0.7"
 url = "1.2"
+tokio-core = "0.1"
+futures = "0.1"
 
 [[bench]]
 harness = false

--- a/benches/clique.rs
+++ b/benches/clique.rs
@@ -2,10 +2,9 @@
 extern crate holmes;
 use holmes::simple::*;
 use std::time::Instant;
-use std::thread;
 
 fn run_clique(size: u64) {
-    single(&|holmes: &mut Engine| {
+    single(&|holmes: &mut Engine, core: &mut Core| {
         predicate!(holmes, reachable(uint64, uint64))?;
         predicate!(holmes, edge(uint64, uint64))?;
         for i in 0..(size - 1) {
@@ -18,7 +17,11 @@ fn run_clique(size: u64) {
             rule!(reachable(X, Y) <= edge(X, Y));
             rule!(reachable(X, Y) <= edge(X, Z) & reachable(Z, Y));
             rule!(same_clique(X, Y) <= reachable(X, Y) & reachable(Y, X))
-        })
+        })?;
+
+        core.run(holmes.quiesce()).unwrap();
+
+        Ok(())
     })
 }
 
@@ -30,15 +33,8 @@ fn clique(size: u64) {
 }
 
 fn main() {
-    thread::Builder::new()
-        .stack_size(1024 * 1024 * 1024)
-        .spawn(|| {
-            println!("Warning: Results not statistically valid");
-            for i in &[10, 20, 30, 40, 50, 60, 70, 80, 90, 100] {
-                clique(*i)
-            }
-        })
-        .unwrap()
-        .join()
-        .unwrap();
+    println!("Warning: Results not statistically valid");
+    for i in &[10, 20, 30, 40, 50, 60, 70, 80, 90, 100] {
+        clique(*i)
+    }
 }

--- a/benches/graph.rs
+++ b/benches/graph.rs
@@ -2,10 +2,9 @@
 extern crate holmes;
 use holmes::simple::*;
 use std::time::Instant;
-use std::thread;
 
 fn run_graph(size: u64) {
-    single(&|holmes: &mut Engine| {
+    single(&|holmes: &mut Engine, core: &mut Core| {
         predicate!(holmes, reachable(uint64, uint64))?;
         predicate!(holmes, edge(uint64, uint64))?;
         predicate!(holmes, increasing(uint64, uint64))?;
@@ -29,7 +28,11 @@ fn run_graph(size: u64) {
             rule!(increasing(X, Y) <= edge(X, Z) & increasing(Z, Y), {
                 let (true) = {lt([X], [Z])}
             })
-        })
+        })?;
+
+        core.run(holmes.quiesce()).unwrap();
+
+        Ok(())
     })
 }
 
@@ -41,15 +44,8 @@ fn graph(size: u64) {
 }
 
 fn main() {
-    thread::Builder::new()
-        .stack_size(1024 * 1024 * 1024)
-        .spawn(|| {
-            println!("Warning: Results not statistically valid");
-            for i in &[10, 20, 30, 40, 50, 60, 70, 80, 90, 100] {
-                graph(*i)
-            }
-        })
-        .unwrap()
-        .join()
-        .unwrap();
+    println!("Warning: Results not statistically valid");
+    for i in &[10, 20, 30, 40, 50, 60, 70, 80, 90, 100] {
+        graph(*i)
+    }
 }

--- a/benches/induction.rs
+++ b/benches/induction.rs
@@ -4,7 +4,7 @@ use holmes::simple::*;
 use std::time::Instant;
 
 fn run_induction(size: u64) {
-    single(&|holmes: &mut Engine| {
+    single(&|holmes: &mut Engine, core: &mut Core| {
         holmes_exec!(holmes, {
             predicate!(p(uint64));
             predicate!(q(uint64))
@@ -50,6 +50,9 @@ fn run_induction(size: u64) {
                 pred_name: "q".to_string(),
                 args: vec![1.to_value()],
             })?;
+
+        core.run(holmes.quiesce()).unwrap();
+
         Ok(())
     })
 }

--- a/src/engine/types.rs
+++ b/src/engine/types.rs
@@ -128,7 +128,9 @@ impl PartialEq for MatchExpr {
             (&Unbound, &Unbound) => true,
             (&Var(x), &Var(y)) => x == y,
             (&Const(ref v), &Const(ref vv)) => v == vv,
-            // TODO fix for substr
+            (&SubStr(ref dbe, ref dbe2, ref v), &SubStr(ref dbeb, ref dbeb2, ref vb)) => {
+                (dbe == dbeb) && (dbe2 == dbeb2) && (v == vb)
+            }
             _ => false,
         }
     }

--- a/tests/fact_basic.rs
+++ b/tests/fact_basic.rs
@@ -4,7 +4,7 @@ use holmes::simple::*;
 
 #[test]
 pub fn new_fact_basic() {
-    single(&|holmes: &mut Engine| {
+    single(&|holmes: &mut Engine, _| {
         holmes_exec!(holmes, {
             predicate!(test_pred(string, bytes, uint64));
             fact!(test_pred("foo", vec![3u8, 4u8, 5u8], 7))
@@ -14,7 +14,7 @@ pub fn new_fact_basic() {
 
 #[test]
 pub fn new_fact_type_err() {
-    single(&|holmes: &mut Engine| {
+    single(&|holmes: &mut Engine, _| {
         holmes_exec!(holmes, {
             predicate!(test_pred(string, bytes, uint64));
             should_fail(fact!(test_pred(7, vec![3u8, 4u8, 5u8], 7)))
@@ -24,7 +24,7 @@ pub fn new_fact_type_err() {
 
 #[test]
 pub fn new_fact_echo() {
-    single(&|holmes: &mut Engine| {
+    single(&|holmes: &mut Engine, _| {
         try!(holmes_exec!(holmes, {
             predicate!(test_pred(string, bytes, uint64));
             fact!(test_pred("foo", vec![3u8, 3u8], 7))
@@ -38,7 +38,7 @@ pub fn new_fact_echo() {
 
 #[test]
 pub fn two_strings() {
-    single(&|holmes: &mut Engine| {
+    single(&|holmes: &mut Engine, _| {
         holmes_exec!(holmes, {
             predicate!(test_pred(string, string));
             fact!(test_pred("foo", "bar"))

--- a/tests/func_basic.rs
+++ b/tests/func_basic.rs
@@ -4,7 +4,7 @@ use holmes::simple::*;
 
 #[test]
 pub fn reg_func() {
-    single(&|holmes: &mut Engine| {
+    single(&|holmes: &mut Engine, _| {
         func!(holmes,
       let test_func : uint64 -> uint64 =
         |_v : &u64| {

--- a/tests/issue_00010.rs
+++ b/tests/issue_00010.rs
@@ -12,7 +12,7 @@ use holmes::simple::*;
 // Bug fixed by moving all ON clauses to the last one.
 #[test]
 fn misordered_join() {
-    single(&|holmes: &mut Engine| {
+    single(&|holmes: &mut Engine, core: &mut Core| {
         holmes_exec!(holmes, {
     predicate!(out(string, uint64, uint64));
     predicate!(assoc(string, uint64, uint64));
@@ -21,6 +21,8 @@ fn misordered_join() {
              assoc(name, [_], tgt) &
              look(name, addr, [_], next) &
              out(name, addr, tgt))
-    })
+    })?;
+        core.run(holmes.quiesce()).unwrap();
+        Ok(())
     })
 }

--- a/tests/metadata_basic.rs
+++ b/tests/metadata_basic.rs
@@ -4,7 +4,7 @@ use holmes::simple::*;
 
 #[test]
 pub fn new_predicate_named_field() {
-    single(&|holmes: &mut Engine| {
+    single(&|holmes: &mut Engine, _| {
         holmes_exec!(holmes, {
             predicate!(test_pred([first string], bytes, uint64))
         })
@@ -13,7 +13,7 @@ pub fn new_predicate_named_field() {
 
 #[test]
 pub fn new_predicate_doc_field() {
-    single(&|holmes: &mut Engine| {
+    single(&|holmes: &mut Engine, _| {
         holmes_exec!(holmes, {
             predicate!(test_pred([first string "This is the first element"], bytes, uint64))
         })
@@ -22,7 +22,7 @@ pub fn new_predicate_doc_field() {
 
 #[test]
 pub fn new_predicate_doc_all() {
-    single(&|holmes: &mut Engine| {
+    single(&|holmes: &mut Engine, _| {
         holmes_exec!(holmes, {
             predicate!(test_pred([first string "This is the first element"],
                                   bytes, uint64)
@@ -33,7 +33,7 @@ pub fn new_predicate_doc_all() {
 
 #[test]
 pub fn predicate_roundtrip() {
-    single(&|holmes: &mut Engine| {
+    single(&|holmes: &mut Engine, _| {
         holmes_exec!(holmes, {
             predicate!(test_pred([first string "This is the first element"],
                                  bytes, uint64)
@@ -49,7 +49,7 @@ pub fn predicate_roundtrip() {
 
 #[test]
 pub fn named_field_rule() {
-    single(&|holmes: &mut Engine| {
+    single(&|holmes: &mut Engine, core: &mut Core| {
         holmes_exec!(holmes, {
             predicate!(test_pred([foo string],
                                  uint64,
@@ -59,6 +59,8 @@ pub fn named_field_rule() {
             fact!(test_pred("woo", 3, "Right"));
             fact!(test_pred("wow", 4, "Wrong"))
         })?;
+
+        core.run(holmes.quiesce()).unwrap();
 
         let ans = query!(holmes, out_pred(x))?;
         assert_eq!(ans, vec![["Right".to_value()]]);

--- a/tests/predicate_basic.rs
+++ b/tests/predicate_basic.rs
@@ -4,7 +4,7 @@ use holmes::simple::*;
 
 #[test]
 pub fn new_predicate_basic() {
-    single(&|holmes: &mut Engine| {
+    single(&|holmes: &mut Engine, _| {
         holmes_exec!(holmes, {
             predicate!(test_pred(string, bytes, uint64))
         })
@@ -13,7 +13,7 @@ pub fn new_predicate_basic() {
 
 #[test]
 pub fn double_register_incompat() {
-    single(&|holmes: &mut Engine| {
+    single(&|holmes: &mut Engine, _| {
         holmes_exec!(holmes, {
             predicate!(test_pred(string, bytes, uint64));
             should_fail(predicate!(test_pred(string, string, string)))
@@ -23,7 +23,7 @@ pub fn double_register_incompat() {
 
 #[test]
 pub fn double_register_compat() {
-    single(&|holmes: &mut Engine| {
+    single(&|holmes: &mut Engine, _| {
         holmes_exec!(holmes, {
             predicate!(test_pred(string, bytes, uint64));
             predicate!(test_pred(string, bytes, uint64))

--- a/tests/reboot.rs
+++ b/tests/reboot.rs
@@ -4,17 +4,17 @@ use holmes::simple::*;
 
 #[test]
 fn simple() {
-    multi(&[&|_holmes: &mut Engine| Ok(()), &|_holmes: &mut Engine| Ok(())])
+    multi(&[&|_holmes: &mut Engine, _| Ok(()), &|_holmes: &mut Engine, _| Ok(())])
 }
 
 #[test]
 fn pred_compat() {
-    multi(&[&|holmes: &mut Engine| {
+    multi(&[&|holmes: &mut Engine, _| {
                 holmes_exec!(holmes, {
                     predicate!(test_pred(bytes, uint64))
                 })
             },
-            &|holmes: &mut Engine| {
+            &|holmes: &mut Engine, _| {
                 holmes_exec!(holmes, {
                     predicate!(test_pred(bytes, uint64))
                 })
@@ -23,12 +23,12 @@ fn pred_compat() {
 
 #[test]
 fn pred_incompat() {
-    multi(&[&|holmes: &mut Engine| {
+    multi(&[&|holmes: &mut Engine, _| {
                 holmes_exec!(holmes, {
                     predicate!(test_pred(bytes, uint64))
                 })
             },
-            &|holmes: &mut Engine| {
+            &|holmes: &mut Engine, _| {
                 holmes_exec!(holmes, {
                     should_fail(predicate!(test_pred(bytes, uint64, uint64)))
                 })
@@ -37,13 +37,13 @@ fn pred_incompat() {
 
 #[test]
 fn fact_preserve() {
-    multi(&[&|holmes: &mut Engine| {
+    multi(&[&|holmes: &mut Engine, _| {
                 holmes_exec!(holmes, {
                     predicate!(test_pred(string, uint64));
                     fact!(test_pred("foo", 7))
                 })
             },
-            &|holmes: &mut Engine| {
+            &|holmes: &mut Engine, _| {
                 assert_eq!(query!(holmes, test_pred(("foo"), x)).unwrap(),
                            vec![vec![7.to_value()]]);
                 Ok(())

--- a/tests/reorder.rs
+++ b/tests/reorder.rs
@@ -1,0 +1,22 @@
+#[macro_use]
+extern crate holmes;
+use holmes::simple::*;
+
+// Ensures that rules will wake up both rules declared before and after them
+#[test]
+pub fn reorder() {
+    single(&|holmes: &mut Engine, core: &mut Core| {
+        holmes_exec!(holmes, {
+            predicate!(foo(uint64));
+            rule!(foo((2)) <= foo((1)));
+            rule!(foo((1)) <= foo((0)));
+            rule!(foo((3)) <= foo((2)));
+            fact!(foo(0))
+        })?;
+
+        core.run(holmes.quiesce()).unwrap();
+
+        assert_eq!(query!(holmes, foo((3)))?.len(), 1);
+        Ok(())
+    })
+}

--- a/tests/rule_basic.rs
+++ b/tests/rule_basic.rs
@@ -4,12 +4,13 @@ use holmes::simple::*;
 
 #[test]
 pub fn one_step() {
-    single(&|holmes: &mut Engine| {
+    single(&|holmes: &mut Engine, core: &mut Core| {
         try!(holmes_exec!(holmes, {
       predicate!(test_pred(string, bytes, uint64));
       fact!(test_pred("foo", vec![3u8;3], 7));
       rule!(test_pred(("bar"), (vec![2u8;2]), x) <= test_pred(("foo"), [_], x))
     }));
+        core.run(holmes.quiesce()).unwrap();
         assert_eq!(query!(holmes, test_pred(("bar"), [_], x)).unwrap(),
                vec![vec![7.to_value()]]);
         Ok(())
@@ -18,7 +19,7 @@ pub fn one_step() {
 
 #[test]
 pub fn closure() {
-    single(&|holmes: &mut Engine| {
+    single(&|holmes: &mut Engine, core: &mut Core| {
         try!(holmes_exec!(holmes, {
       predicate!(reaches(string, string));
       fact!(reaches("foo", "bar"));
@@ -26,6 +27,7 @@ pub fn closure() {
       fact!(reaches("baz", "bang"));
       rule!(reaches(src, dst) <= reaches(src, mid) & reaches(mid, dst))
     }));
+        core.run(holmes.quiesce()).unwrap();
         let ans = try!(query!(holmes, reaches(("foo"), tgt)));
         assert_eq!(ans, vec![["bar".to_value()], ["baz".to_value()], ["bang".to_value()]]);
         Ok(())

--- a/tests/rule_substr.rs
+++ b/tests/rule_substr.rs
@@ -4,7 +4,7 @@ use holmes::simple::*;
 
 #[test]
 pub fn simple_substr() {
-    single(&|holmes: &mut Engine| {
+    single(&|holmes: &mut Engine, core: &mut Core| {
         try!(holmes_exec!(holmes, {
       predicate!(test_pred(uint64, bytes));
       predicate!(sub(uint64, bytes));
@@ -12,6 +12,7 @@ pub fn simple_substr() {
       fact!(test_pred(2, vec![1u8, 2u8, 3u8]));
       rule!(sub(n, x) <= test_pred(n, {(1), (2), x}))
     }));
+        core.run(holmes.quiesce()).unwrap();
         assert_eq!(query!(holmes, sub((1), x)).unwrap(),
                vec![vec![(vec![2u8, 1u8]).to_value()]]);
         assert_eq!(query!(holmes, sub((2), x)).unwrap(),
@@ -22,7 +23,7 @@ pub fn simple_substr() {
 
 #[test]
 pub fn param_substr() {
-    single(&|holmes: &mut Engine| {
+    single(&|holmes: &mut Engine, core: &mut Core| {
         try!(holmes_exec!(holmes, {
       predicate!(test_pred(uint64, bytes));
       predicate!(sub(uint64, bytes));
@@ -30,6 +31,7 @@ pub fn param_substr() {
       fact!(test_pred(2, vec![1u8, 2u8, 3u8]));
       rule!(sub(n, x) <= test_pred(n, {[n], (2), x}))
     }));
+        core.run(holmes.quiesce()).unwrap();
         assert_eq!(query!(holmes, sub((1), x)).unwrap(),
                vec![vec![(vec![2u8, 1u8]).to_value()]]);
         assert_eq!(query!(holmes, sub((2), x)).unwrap(),

--- a/tests/rule_where.rs
+++ b/tests/rule_where.rs
@@ -4,18 +4,20 @@ use holmes::simple::*;
 
 #[test]
 pub fn register_where_rule() {
-    single(&|holmes: &mut Engine| {
+    single(&|holmes: &mut Engine, core: &mut Core| {
         holmes_exec!(holmes, {
       predicate!(test_pred(string, bytes, uint64));
       rule!(test_pred(("bar"), (vec![2u8,2u8]), x) <= test_pred(("foo"), [_], x), {
         let (42) = (42)})
-    })
+    })?;
+        core.run(holmes.quiesce()).unwrap();
+        Ok(())
     })
 }
 
 #[test]
 pub fn where_const() {
-    single(&|holmes: &mut Engine| {
+    single(&|holmes: &mut Engine, core: &mut Core| {
         try!(holmes_exec!(holmes, {
       predicate!(test_pred(string, bytes, uint64));
       rule!(test_pred(("bar"), (vec![2u8,2u8]), x) <= test_pred(("foo"), [_], [_]), {
@@ -23,6 +25,7 @@ pub fn where_const() {
       });
       fact!(test_pred("foo", vec![0u8,1u8], 16))
     }));
+        core.run(holmes.quiesce()).unwrap();
         assert_eq!(query!(holmes, test_pred(("bar"), x, y)).unwrap(),
                vec![vec![vec![2u8,2u8].to_value(), 42.to_value()]]);
         Ok(())
@@ -31,7 +34,7 @@ pub fn where_const() {
 
 #[test]
 pub fn where_plus_two() {
-    single(&|holmes: &mut Engine| {
+    single(&|holmes: &mut Engine, core: &mut Core| {
         try!(holmes_exec!(holmes, {
       predicate!(test_pred(string, bytes, uint64));
       func!(let plus_two : uint64 -> uint64 = |v : &u64| {v + 2});
@@ -40,6 +43,7 @@ pub fn where_plus_two() {
       });
       fact!(test_pred("foo", vec![0u8,1u8], 16))
     }));
+        core.run(holmes.quiesce()).unwrap();
         assert_eq!(query!(holmes, test_pred(("bar"), x, y)).unwrap(),
                vec![vec![vec![2u8,2u8].to_value(), 18.to_value()]]);
         let res: Result<()> = Ok(());
@@ -49,7 +53,7 @@ pub fn where_plus_two() {
 
 #[test]
 pub fn where_destructure() {
-    single(&|holmes: &mut Engine| {
+    single(&|holmes: &mut Engine, core: &mut Core| {
         try!(holmes_exec!(holmes, {
       predicate!(test_pred(uint64, bytes, uint64));
       func!(let succs : uint64 -> (uint64, uint64) = |n : &u64| {
@@ -60,6 +64,7 @@ pub fn where_destructure() {
       });
       fact!(test_pred(3, vec![0u8,1u8], 16))
     }));
+        core.run(holmes.quiesce()).unwrap();
         assert_eq!(query!(holmes, test_pred(y, (vec![2u8,2u8]), z)).unwrap(),
                vec![vec![17.to_value(), 18.to_value()]]);
         Ok(())
@@ -68,7 +73,7 @@ pub fn where_destructure() {
 
 #[test]
 pub fn where_iter() {
-    single(&|holmes: &mut Engine| {
+    single(&|holmes: &mut Engine, core: &mut Core| {
         try!(holmes_exec!(holmes, {
       predicate!(test_pred(uint64, bytes, uint64));
       func!(let succs : uint64 -> [uint64] = |n : &u64| {
@@ -79,6 +84,7 @@ pub fn where_iter() {
       });
       fact!(test_pred(3, vec![0u8,1u8], 16))
     }));
+        core.run(holmes.quiesce()).unwrap();
         assert_eq!(query!(holmes, test_pred([_], (vec![2u8,2u8]), x)).unwrap(),
                vec![vec![17.to_value()], vec![18.to_value()]]);
         Ok(())

--- a/tests/trivial.rs
+++ b/tests/trivial.rs
@@ -4,12 +4,12 @@ use holmes::simple::*;
 
 #[test]
 pub fn turn_on() {
-    single(&|_holmes: &mut Engine| Ok(()))
+    single(&|_holmes: &mut Engine, _| Ok(()))
 }
 
 #[test]
 pub fn macro_check() {
-    single(&|holmes: &mut Engine| {
+    single(&|holmes: &mut Engine, _| {
         holmes_exec!(holmes, {
         })
     })

--- a/tests/type_extend.rs
+++ b/tests/type_extend.rs
@@ -78,7 +78,7 @@ impl BoolValue {
 
 #[test]
 pub fn add_bool() {
-    single(&|holmes: &mut Engine| {
+    single(&|holmes: &mut Engine, _| {
         try!(holmes.add_type(Arc::new(BoolType)));
         try!(predicate!(holmes, type_pred(uint64, bool2)));
         try!(fact!(holmes, type_pred(32, BoolValue::new(false))));
@@ -93,18 +93,18 @@ pub fn add_bool() {
 
 #[test]
 fn reboot() {
-    multi(&[&|holmes: &mut Engine| holmes.add_type(Arc::new(BoolType)),
-            &|_holmes: &mut Engine| Ok(())])
+    multi(&[&|holmes: &mut Engine, _| holmes.add_type(Arc::new(BoolType)),
+            &|_holmes: &mut Engine, _| Ok(())])
 }
 
 #[test]
 fn reboot_reuse() {
-    multi(&[&|holmes: &mut Engine| {
+    multi(&[&|holmes: &mut Engine, _| {
                 try!(holmes.add_type(Arc::new(BoolType)));
                 try!(predicate!(holmes, type_pred(uint64, bool2)));
                 fact!(holmes, type_pred(32, BoolValue::new(false)))
             },
-            &|holmes: &mut Engine| {
+            &|holmes: &mut Engine, _| {
         try!(holmes.add_type(Arc::new(BoolType)));
         try!(predicate!(holmes, type_pred(uint64, bool2)));
         try!(fact!(holmes, type_pred(42, BoolValue::new(true))));


### PR DESCRIPTION
Rather than using recursion to trigger one rule from another, I've
restructured them as async tasks using `tokio_core`. This also paves
the way for the use of `tokio_postgres` to get asynchronous database
interaction for improved database performance.

Closes #15 #26